### PR TITLE
Added profiler deletion functionality and profile existence check

### DIFF
--- a/contracts/SBT.sol
+++ b/contracts/SBT.sol
@@ -96,7 +96,7 @@ contract SBT {
         return profiles[_soul];
     }
 
-    function hasProfile(address _profiler, address _soul) external view returns (bool) {
+    function hasProfile(address _profiler, address _soul) public view returns (bool) {
         if (keccak256(bytes(soulProfiles[_profiler][_soul].identity)) == zeroHash) {
             return false;
         } else {
@@ -106,7 +106,16 @@ contract SBT {
 
     function removeProfile(address _profiler, address _soul) external {
         require(msg.sender == _soul, "Only users have rights to delete their profile data");
+        require(hasProfile(_profiler, _soul), "Profile does not exist");
         delete soulProfiles[_profiler][msg.sender];
+        uint profileLength = profiles[_soul].length;
+        for (uint i=0; i<profileLength; i++) {
+            if (profiles[_soul][i] == _profiler) {
+                profiles[_soul][i] = profiles[_soul][profileLength - 1];
+                profiles[_soul].pop();
+                break;
+            }
+        }
         emit RemoveProfile(_profiler, _soul);
     }
 }


### PR DESCRIPTION
This commit modifies the removeProfile function in the SBT contract to add a check for the existence of the profile before removing it, to avoid caller's further gas consumption for non-existing profile. Additionally, the function now removes the _profiler address from the profiles list for _soul.